### PR TITLE
Add 'ProvisionsAllDevices key' to provisioning profile and raise swift-tools version to 5.5.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,23 +1,17 @@
-// swift-tools-version:4.0
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription
 
 let package = Package(
     name: "SwiftyProvisioningProfile",
+    platforms: [.macOS(.v10_13)],
     products: [
-        // Products define the executables and libraries produced by a package, and make them visible to other packages.
         .library(
             name: "SwiftyProvisioningProfile",
             targets: ["SwiftyProvisioningProfile"]),
     ],
-    dependencies: [
-        // Dependencies declare other packages that this package depends on.
-        // .package(url: /* package url */, from: "1.0.0"),
-    ],
     targets: [
-        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
-        // Targets can depend on other targets in this package, and on products in packages which this package depends on.
         .target(
             name: "SwiftyProvisioningProfile",
             dependencies: []),

--- a/Sources/SwiftyProvisioningProfile/Model/ProvisioningProfile.swift
+++ b/Sources/SwiftyProvisioningProfile/Model/ProvisioningProfile.swift
@@ -17,6 +17,7 @@ public struct ProvisioningProfile: Codable, Equatable {
         case expirationDate = "ExpirationDate"
         case name = "Name"
         case provisionedDevices = "ProvisionedDevices"
+        case provisionsAllDevices = "ProvisionsAllDevices"
         case teamIdentifiers = "TeamIdentifier"
         case teamName = "TeamName"
         case timeToLive = "TimeToLive"
@@ -39,7 +40,7 @@ public struct ProvisioningProfile: Codable, Equatable {
     /// The array of Base64 encoded developer certificates
     public var developerCertificates: [DeveloperCertificate]
     
-    /// The key value pair of entitlements assosciated with this profile
+    /// The key value pair of entitlements associated with this profile
     public var entitlements: [String: PropertyListDictionaryValue]
     
     /// The date in which this profile will expire
@@ -51,6 +52,9 @@ public struct ProvisioningProfile: Codable, Equatable {
     /// An array of device UUIDs that are provisioned on this profile
     public var provisionedDevices: [String]?
     
+    /// A key indicating whether the profile provisions all devices. This is present when profile is generated for enterprise distribution.
+    public var provisionsAllDevices: Bool?
+
     /// An array of team identifier of which this profile belongs to
     public var teamIdentifiers: [String]
     

--- a/Sources/SwiftyProvisioningProfile/SwiftyCertificate.swift
+++ b/Sources/SwiftyProvisioningProfile/SwiftyCertificate.swift
@@ -6,17 +6,16 @@
 //
 
 import Foundation
-import Security
 
 public extension Certificate {
     
-    public enum ParseError: Error {
+    enum ParseError: Error {
         case failedToCreateCertificate
         case failedToCreateTrust
         case failedToExtractValues
     }
     
-    public static func parse(from data: Data) throws -> Certificate {
+    static func parse(from data: Data) throws -> Certificate {
         let certificate = try getSecCertificate(data: data)
         
         var error: Unmanaged<CFError>?

--- a/Sources/SwiftyProvisioningProfile/SwiftyProvisioningProfile.swift
+++ b/Sources/SwiftyProvisioningProfile/SwiftyProvisioningProfile.swift
@@ -6,7 +6,7 @@ import Foundation
 
 public extension ProvisioningProfile {
     
-    public enum ParseError: Error {
+    enum ParseError: Error {
         case failedToCreateDecoder
         case failedToCreateData
     }


### PR DESCRIPTION
The `ProvisionsAllDevices` key is a good indicator of enterprise distribution certificate.

I bumped swift-tools version because Bazel [rules_swift_package_manager](https://github.com/cgrindel/rules_swift_package_manager) don't support dumping package description for swift-tools versions older than 5.2.

Finally, I fixed a few warnings.